### PR TITLE
Added a runAsSystem switch to allow running in a scheduled task

### DIFF
--- a/Reset-KrbTgt-Password-For-RWDCs-And-RODCs.ps1
+++ b/Reset-KrbTgt-Password-For-RWDCs-And-RODCs.ps1
@@ -327,6 +327,10 @@ $version = "v3.4, 2023-03-04"
 		determined. In case the RODC is not available or its "source" server is not available, the RWDC with the PDC FSMO is used to reset
 		the password of the krbtgt account in use by that RODC. If the RODC is available a check will be done against its database, and if
 		not available the check is skipped
+	- The -runAsSystem parameter is for automation. It can ONLY be used when the domain is local and the script is running as SYSTEM on a
+		DC with FSMO Role PDC Emulator. The privilege checks of Domain and Enterprise Admins group memberships are replaced with NT AUTHORITY/SYSTEM
+		checks. Since it is not interactive, the -NoInfo and -ContinueOps parameters are implicitly true. However, the modeOfOperation and
+		targetKrbTgtAccountScope parameters must be provided.
 
 .PARAMETER noInfo
 	With this parameter it is possible to skip the information at the beginning of the script when running the script in an automated manner such
@@ -426,6 +430,11 @@ $version = "v3.4, 2023-03-04"
 	Execute The Script - Automated And Sending The Log File Through Mail - Mode 6 With Specific RODCs (But Not All) As Scope
 
 	.\Reset-KrbTgt-Password-For-RWDCs-And-RODCs.ps1 -noInfo -modeOfOperation resetModeKrbTgtProdAccountsResetOnce -targetedADforestFQDN DOMAIN.COM -targetedADdomainFQDN CHILD.DOMAIN.COM -targetKrbTgtAccountScope specificRODCs -targetRODCFQDNList "RODC1.DOMAIN.COM","RODC2.DOMAIN.COM","RODC3.DOMAIN.COM" -continueOps -sendMailWithLogFile
+
+	.EXAMPLE
+	Execute The Script - Automated And Sending The Log File Through Mail - Mode 6 With All RWDCs As Scope - Running as SYSTEM on PDC Emulator
+
+	.\Reset-KrbTgt-Password-For-RWDCs-And-RODCs.ps1 -noInfo -modeOfOperation resetModeKrbTgtProdAccountsResetOnce -targetedADforestFQDN DOMAIN.COM -targetedADdomainFQDN CHILD.DOMAIN.COM -targetKrbTgtAccountScope allRWDCs -continueOps -sendMailWithLogFile
 
 .NOTES
 	- Required PoSH CMDlets: GPMC PoSH CMDlets on all targeted RWDCs!!! (and the S.DS.P Posh CMDlets are INCLUDED in this script!)

--- a/Reset-KrbTgt-Password-For-RWDCs-And-RODCs.ps1
+++ b/Reset-KrbTgt-Password-For-RWDCs-And-RODCs.ps1
@@ -1,36 +1,38 @@
 ###
 # Parameters Used By Script
 ###
-[CmdletBinding(DefaultParameterSetName = "Interactive")]
+[CmdletBinding(DefaultParameterSetName = "On-demand")]
 Param (
-	[Parameter(Mandatory=$false, ParameterSetName="Interactive")]
+	[Parameter(Mandatory=$false, ParameterSetName="On-demand")]
 	[switch]$noInfo,
 
-	[Parameter(Mandatory=$false, ParameterSetName="Interactive")]
+	[Parameter(Mandatory=$false, ParameterSetName="On-demand")]
 	[Parameter(Mandatory=$true, ParameterSetName="Automation")]
 	[ValidateSet("infoMode", "simulModeCanaryObject", "simulModeKrbTgtTestAccountsWhatIf", "resetModeKrbTgtTestAccountsResetOnce", "simulModeKrbTgtProdAccountsWhatIf", "resetModeKrbTgtProdAccountsResetOnce")]
 	[string]$modeOfOperation,
 
-	[Parameter(Mandatory=$false, ParameterSetName="Interactive")]
+	[Parameter(Mandatory=$false, ParameterSetName="On-demand")]
 	[Parameter(Mandatory=$false, ParameterSetName="Automation")]
 	[string]$targetedADforestFQDN,
 
-	[Parameter(Mandatory=$false, ParameterSetName="Interactive")]
+	[Parameter(Mandatory=$false, ParameterSetName="On-demand")]
 	[Parameter(Mandatory=$false, ParameterSetName="Automation")]
 	[string]$targetedADdomainFQDN,
 
-	[Parameter(Mandatory=$false, ParameterSetName="Interactive")]
+	[Parameter(Mandatory=$false, ParameterSetName="On-demand")]
 	[Parameter(Mandatory=$true, ParameterSetName="Automation")]
 	[ValidateSet("allRWDCs", "allRODCs", "specificRODCs")]
 	[string]$targetKrbTgtAccountScope,
 
-	[Parameter(Mandatory=$false, ParameterSetName="Interactive")]
+	[Parameter(Mandatory=$false, ParameterSetName="On-demand")]
 	[Parameter(Mandatory=$false, ParameterSetName="Automation")]
 	[string[]]$targetRODCFQDNList,
 
-	[Parameter(Mandatory=$false, ParameterSetName="Interactive")]
+	[Parameter(Mandatory=$false, ParameterSetName="On-demand")]
 	[switch]$continueOps,
 
+	[Parameter(Mandatory=$false, ParameterSetName="On-demand")]
+	[Parameter(Mandatory=$false, ParameterSetName="Automation")]
 	[switch]$sendMailWithLogFile,
 
 	[Parameter(Mandatory=$true, ParameterSetName="Automation")]
@@ -329,7 +331,7 @@ $version = "v3.4, 2023-03-04"
 		not available the check is skipped
 	- The -runAsSystem parameter is for automation. It can ONLY be used when the domain is local and the script is running as SYSTEM on a
 		DC with FSMO Role PDC Emulator. The privilege checks of Domain and Enterprise Admins group memberships are replaced with NT AUTHORITY/SYSTEM
-		checks. Since it is not interactive, the -NoInfo and -ContinueOps parameters are implicitly true. However, the modeOfOperation and
+		checks. Since it is not On-demand, the -NoInfo and -ContinueOps parameters are implicitly true. However, the modeOfOperation and
 		targetKrbTgtAccountScope parameters must be provided.
 
 .PARAMETER noInfo
@@ -3159,7 +3161,7 @@ Function loadPoSHModules($poshModule, $ignoreRemote) {
 		} Else {
 			Logging "PoSH Module '$poshModule' Is Not Available To Load..." "ERROR" $ignoreRemote
 			Logging "The PoSH Module '$poshModule' Is Required For This Script To Work..." "REMARK" $ignoreRemote
-			If ($PSCmdlet.ParameterSetName -eq "Interactive"){
+			If ($PSCmdlet.ParameterSetName -eq "On-demand"){
 				$confirmInstallPoshModuleYESNO = $null
 				$confirmInstallPoshModuleYESNO = Read-Host "Would You Like To Install The PoSH Module '$poshModule' NOW? [Yes|No]"
 				If ($confirmInstallPoshModuleYESNO.ToUpper() -eq "YES" -Or $confirmInstallPoshModuleYESNO.ToUpper() -eq "Y") {
@@ -5294,18 +5296,10 @@ Add-Type -Path $(($sdspDLLPath | Sort-Object -Property ProductVersion)[0].FullNa
 ###
 # Check if running as SYSTEM in an automated task
 ###
-Logging "------------------------------------------------------------------------------------------------------------------------------------------------------" "HEADER"
-Logging "INFORMATION REGARDING SCRIPT MODE..." "HEADER"
-Logging ""
-
 If ($PSCmdlet.ParameterSetName -eq "Automation"){
 	$noInfo = $true
 	$continueOps = $true
-	Logging "Running Mode: AUTOMATION" "REMARK"
-} Else {
-	Logging "Running Mode: INTERACTIVE" "REMARK"
 }
-Logging ""
 
 ###
 # Technical Information
@@ -5656,7 +5650,7 @@ Switch ($modeOfOperation) {
 	Default {$modeOfOperationNr = $null}
 }
 If ($null -eq $modeOfOperationNr) {
-	If ($PSCmdlet.ParameterSetName -eq "Interactive"){
+	If ($PSCmdlet.ParameterSetName -eq "On-demand"){
 		Logging "Please specify the mode of operation: " "ACTION-NO-NEW-LINE"
 		$modeOfOperationNr = Read-Host
 	}
@@ -5741,7 +5735,7 @@ Logging ""
 
 # Ask Which AD Forest To Target
 If ($targetedADforestFQDN -eq "") {
-	If ($PSCmdlet.ParameterSetName -eq "Interactive") {
+	If ($PSCmdlet.ParameterSetName -eq "On-demand") {
 		Logging "For the AD forest to be targeted, please provide the FQDN or press [ENTER] for the current AD forest: " "ACTION-NO-NEW-LINE"
 		$targetedADforestFQDN = Read-Host
 	}
@@ -7629,7 +7623,7 @@ If ($modeOfOperationNr -eq 2 -Or $modeOfOperationNr -eq 3 -Or $modeOfOperationNr
 		Default {$targetKrbTgtAccountNr = $null}
 	}
 	If ($null -eq $targetKrbTgtAccountNr) {
-		If ($PSCmdlet.ParameterSetName -eq "Interactive") {
+		If ($PSCmdlet.ParameterSetName -eq "On-demand") {
 			Logging "Please specify the scope of KrbTgt Account to target: " "ACTION-NO-NEW-LINE"
 			$targetKrbTgtAccountNr = Read-Host
 		} Else {


### PR DESCRIPTION
The PR includes changes regarding a very specific usage. The usage of word Automation became blurry with this change but understandable.

In original script, ON-DEMAND mode means no parameters defined, so all responses to be prompted interactively. And AUTOMATION means, there is at least one parameter defined. However, in AUTOMATION mode, it is possible for the script to prompt the user. It is still interactive depending on the workflow.

In my case, I used AUTOMATION in the sense that if there is a critical information missing, it will be logging the error and exit.

I though about replacing it with DEFAULT and QUIET, but not sure.

That's why I keep it a draft PR until we are on the same page.

